### PR TITLE
Support British English term "licence"

### DIFF
--- a/server.rb
+++ b/server.rb
@@ -140,7 +140,7 @@ class AddALicense < Sinatra::Base
         request = Typhoeus::Request.new("https://api.github.com/repos/#{repo.full_name}/contents?access_token=#{ENV['GH_ADDALICENSE_ACCESS_TOKEN']}")
         request.on_complete do |response|
           if response.success?
-            public_repos << repo unless JSON.load(response.response_body).any? {|f| f["name"] =~ /^(UNLICENSE|LICENSE|COPYING)\.?/i}
+            public_repos << repo unless JSON.load(response.response_body).any? {|f| f["name"] =~ /^(UNLICENSE|LICENSE|COPYING|LICENCE)\.?/i}
           elsif response.timed_out?
             p "#{repo.full_name} got a time out"
           elsif response.code == 0


### PR DESCRIPTION
I use the British English spelling of LICENCE (rather than LICENSE) in my code, and addalicense.com thought lots of my projects did not have a licence.

This (untested) simple patch should make addalicense.com support that idiom as well.
