### PR TITLE
Point BSD-2 license to ISC

### DIFF
--- a/deps/licenses.yml
+++ b/deps/licenses.yml
@@ -11,8 +11,8 @@
 - :title: BSD (3-Clause) License
   :link: bsd-3-clause
   :filename: 
-- :title: BSD 2-Clause license
-  :link: bsd
+- :title: BSD (2-Clause) license
+  :link: isc
   :filename: 
 - :title: Eclipse Public License v1.0
   :link: eclipse


### PR DESCRIPTION
As per the discussion in github/choosealicense.com#50, the default license in the BSD group is the ISC, which is for all purposes identical to the BSD 2-clause, but even simpler.